### PR TITLE
build before publish

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -96,6 +96,7 @@ module.exports = {
 }
 
 @Task()
+@Depends(build) //analyze, build, test, runAtomTests)
 publish() => publishAtomPlugin();
 
 @DefaultTask()


### PR DESCRIPTION
I've been using this same build-before-publish in the [dartino plugin's `grind.dart`](https://github.com/dartino/atom-dartino/blob/master/tool/grind.dart#L29) for a while now. It ensures that the published JS always matches the published source.

@devoncarew 
